### PR TITLE
Fix package main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "basic-express",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
     "test": "jest",
     "start": "node app.js",


### PR DESCRIPTION
## Summary
- fix package entry point in package.json so `require("basic-express")` works

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f81cf61b8832db81787e8d92368af